### PR TITLE
improve: recommend pipx over pip for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ Install rkale in your project using poetry:
 poetry add rkale
 ```
 
-Use pip if you want a global installation:
+Use `pipx` if you want a global installation:
 
 ```bash
-pip install rkale
+pipx install rkale
 ```
+
+`pipx` installs it in an isolated environment to not mess with the rest of your system.
 
 ## Configuration
 


### PR DESCRIPTION
Manjaros new default to not allow global pip install since it can damage the system:
```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try 'pacman -S
    python-xyz', where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Arch-packaged Python package,
    create a virtual environment using 'python -m venv path/to/venv'.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip.
    
    If you wish to install a non-Arch packaged Python application,
    it may be easiest to use 'pipx install xyz', which will manage a
    virtual environment for you. Make sure you have python-pipx
    installed via pacman.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```
following PEP668
https://peps.python.org/pep-0668/

https://github.com/pypa/pipx